### PR TITLE
Cl args and window resize

### DIFF
--- a/com/cinnamon/demo/DemoCanvas.java
+++ b/com/cinnamon/demo/DemoCanvas.java
@@ -60,6 +60,13 @@ public final class DemoCanvas extends Canvas2D<ConcurrentSceneBuffer,
     }
 
     @Override
+    protected void onResize()
+    {
+        // Update GLBuffer's projection matrix since resolution changed
+        mBuffer.setProjection(getProjection());
+    }
+
+    @Override
     protected void draw(ConcurrentSceneBuffer input, ShaderFactory factory)
     {
         // Fill window background with color

--- a/com/cinnamon/demo/DemoDriver.java
+++ b/com/cinnamon/demo/DemoDriver.java
@@ -109,7 +109,7 @@ public class DemoDriver
         final boolean debugEnabled = props.get(Game.DEBUG_MODE).equals(Game.PROPERTY_ENABLE);
 
         // Setup Window for Canvas drawing
-        final Window window = new Window(resolution[0], resolution[1], props.get(Game.TITLE), null, debugEnabled);
+        final Window window = new Window(resolution[0], resolution[1], props.get(Game.TITLE), debugEnabled);
 
         // Prepare game resource such as factories
         final Game.Resources res = new CustomResources();

--- a/com/cinnamon/demo/DemoDriver.java
+++ b/com/cinnamon/demo/DemoDriver.java
@@ -50,40 +50,66 @@ import java.util.Map;
  *     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  *     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *</p>
- *
+ * <br><br>
  * <p>
  *     Entry point for the Cinnamon engine.
+ * </p>
+ *
+ * <p>
+ *     Arguments must be in one of two formats, either specifying an explicit resolution <i>{@literal <#x#> <true|false
+ *     debug> <tickrate> <true|false vsync>}</i> or the subset <i>{@literal <true|false debug> <tickrate> <true|false
+ *     vsync>}</i> where the latter format will cause the {@link Window} to launch in fullscreen.
+ * </p>
+ *
+ * <p>
+ *     The Window will only be resizable when using the explicit resolution format with {@literal <i><debug></i>} as
+ *     true. The current minimum supported Window size is {@link Window#MINIMUM_WIDTH} x {@link Window#MINIMUM_HEIGHT}.
+ *     If a size smaller than the minimum or larger than the display supports is given, the Window will default to
+ *     fullscreen and act as if the fullscreen resolution format was used.
  * </p>
  */
 public class DemoDriver
 {
-    // Window and Canvas dimensions
-    private static final int WIDTH = 1920;
-    private static final int HEIGHT = 1080;
-
     // Game property values
     private static final String TITLE = "Simple Demo";
     private static final String DEVELOPER = "Christian Ramos";
     private static final String VERSION = "0.01a";
-    private static final String VSYNC = Game.PROPERTY_ENABLE;
-    private static final String TICKRATE = "60";
-    private static final String TICK_SAMPLES = "10";
-    private static final String DEBUG = Game.PROPERTY_ENABLE;
+    private static final String TICK_SAMPLES = "3";
+
+    // Argument count for explicit resolution format
+    private static final int EXPLICIT_RES_ARGS = 4;
+
+    // Argument count for fullscreen arg format
+    private static final int FULL_RES_ARGS = 3;
+
+    // Argument format for explicit resolution
+    private static final String ARG_FORMAT = "<#x#> <true|false debug> <tickrate> <true|false vsync>";
 
     public static void main(String[] args)
     {
-        // Setup game info
-        final Map<String, String> props = new HashMap<String, String>();
-        props.put(Game.TITLE, TITLE);
-        props.put(Game.DEVELOPER, DEVELOPER);
-        props.put(Game.VERSION, VERSION);
-        props.put(Game.VSYNC, VSYNC);
-        props.put(Game.DEBUG_MODE, DEBUG);
-        props.put(Game.TICKRATE, TICKRATE);
-        props.put(Game.RATE_SAMPLES, TICK_SAMPLES);
+        // Check argument count mismatch
+        if (args.length != FULL_RES_ARGS && args.length != EXPLICIT_RES_ARGS) {
+            throw new IllegalArgumentException("CL arguments must be in one of two formats: " + ARG_FORMAT + " where " +
+                    "the resolution argument \"<#x#>\" is optional");
+        }
+
+        // Translate arguments to properties to be fed to Game
+        final Map<String, String> props = buildPropertiesFromArgs(args);
+
+        // Read resolution from arguments if explicit length
+        final int[] resolution;
+        if (args.length == EXPLICIT_RES_ARGS) {
+            resolution = getResolution(0, args);
+        } else {
+            // Dimensions higher than display can handle will force fullscreen
+            resolution = new int[] {Integer.MAX_VALUE, Integer.MAX_VALUE};
+        }
+
+        // Check if debug was enabled from args
+        final boolean debugEnabled = props.get(Game.DEBUG_MODE).equals(Game.PROPERTY_ENABLE);
 
         // Setup Window for Canvas drawing
-        final Window window = new Window(WIDTH, HEIGHT, props.get(Game.TITLE), null);
+        final Window window = new Window(resolution[0], resolution[1], props.get(Game.TITLE), null, debugEnabled);
 
         // Prepare game resource such as factories
         final Game.Resources res = new CustomResources();
@@ -96,6 +122,133 @@ public class DemoDriver
         new DemoGame(res, new CustomServices(), canvas, props).start();
     }
 
+    /**
+     * <p>Builds a {@link Map} of properties to submit to {@link Game}'s constructor based off of the given
+     * arguments.</p>
+     *
+     * @param args cl arguments.
+     * @return properties.
+     * @throws IllegalArgumentException if either the debug, tickrate, or vsync arguments' values are invalid (e.g.
+     * tickrate's value is a negative floating point).
+     */
+    private static Map<String, String> buildPropertiesFromArgs(String[] args)
+    {
+        // Setup game info
+        final Map<String, String> props = new HashMap<String, String>();
+        props.put(Game.TITLE, TITLE);
+        props.put(Game.DEVELOPER, DEVELOPER);
+        props.put(Game.VERSION, VERSION);
+        props.put(Game.RATE_SAMPLES, TICK_SAMPLES);
+
+        // Determine index of debug mode arg based on whether format provides explicit resolution
+        final int debugArg = (args.length == EXPLICIT_RES_ARGS) ? 1 : 0;
+
+        // Read and apply arg for debug
+        final String debug = getBooleanArg(debugArg, args);
+        if (debug == null) {
+            throw new IllegalArgumentException("Debug argument must be either \"true\" or \"false\"");
+        }
+        props.put(Game.DEBUG_MODE, getBooleanArg(debugArg, args));
+
+        // Apply desired tickrate
+        final String tickrate = getIntArg(debugArg + 1, args);
+        if (tickrate == null || Integer.parseInt(tickrate) <= 0) {
+            throw new IllegalArgumentException("Tickrate argument must be an int > 0");
+        }
+        props.put(Game.TICKRATE, getIntArg(debugArg + 1, args));
+
+        // Apply vsync arg
+        final String vsync = getBooleanArg(debugArg + 2, args);
+        if (vsync == null) {
+            throw new IllegalArgumentException("Vsync argument must be either \"true\" or \"false\"");
+        }
+        props.put(Game.VSYNC, getBooleanArg(debugArg + 2, args));
+        return props;
+    }
+
+    /**
+     * <p>Returns either {@link Game#PROPERTY_ENABLE} or {@link Game#PROPERTY_DISABLE} depending on whether or not
+     * the argument specified by the given index is "true" or "false", respectively.</p>
+     *
+     * @param index argument index.
+     * @param args arguments.
+     * @return either PROPERTY_ENABLE or PROPERTY_DISABLE.
+     */
+    private static String getBooleanArg(int index, String[] args)
+    {
+        final String argVal = args[index];
+        final boolean argTrue = argVal.equals("true");
+        final boolean argFalse = argVal.equals("false");
+        final String translation;
+
+        // Check if argument if a proper "true" | "false"
+        if (argTrue) {
+            translation = Game.PROPERTY_ENABLE;
+        } else if (argFalse) {
+            translation = Game.PROPERTY_DISABLE;
+        } else {
+            throw new IllegalArgumentException("Argument[" + index + "] must be \"true\" or \"false\":" + args[index]);
+        }
+
+        return translation;
+    }
+
+    /**
+     * <p>Checks whether or not the argument specified by the given index is an int. If the argument is not an int,
+     * this method returns null.</p>
+     *
+     * @param index argument index.
+     * @param args arguments.
+     * @return argument, or null if it is not a valid int.
+     */
+    private static String getIntArg(int index, String[] args)
+    {
+        try {
+            final int val = Integer.valueOf(args[index]);
+            return String.valueOf(val);
+        } catch (NumberFormatException e){
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * <p>Gets the width and height dimensions of an argument formatted as a resolution (e.g. "1920x1080").</p>
+     *
+     * @param index argument index.
+     * @param args arguments.
+     * @return two element array holding width and height, in that order, or null if the dimensions are not ints.
+     */
+    private static int[] getResolution(int index, String[] args)
+    {
+        final String argVal = args[index];
+
+        // Check if valid formatting
+        if (!argVal.matches("[0-9]+x[0-9]+")) {
+            throw new IllegalArgumentException("Resolution argument must be formatted like so: 1920x1080");
+        }
+
+        // Split resolution by the 'x' and convert each dimension to an int
+        final String[] resTokens = argVal.split("x");
+        try {
+            // Try to convert tokens to dimensions
+            final int width = Integer.valueOf(resTokens[0]);
+            final int height = Integer.valueOf(resTokens[1]);
+
+            return new int[] {width, height};
+
+        } catch (NumberFormatException e) {
+            // Should never occur given the regex format check at the beginning
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * <p>
+     *     Provides the {@link Game} with a directory of customized resources for constructing game objects.
+     * </p>
+     */
     private static class CustomResources extends Game.Resources
     {
         private ShaderFactory mShaderFactory = new DemoShaderFactory();
@@ -128,6 +281,12 @@ public class DemoDriver
         }
     }
 
+    /**
+     * <p>
+     *     Returns null for each method returning a service. This tells {@link Game} to provide its own
+     *     implementations.
+     * </p>
+     */
     private static class CustomServices extends Game.Services
     {
         @Override

--- a/com/cinnamon/demo/DemoGame.java
+++ b/com/cinnamon/demo/DemoGame.java
@@ -15,53 +15,70 @@ import java.util.Map;
  * <p>
  *     Demo {@link Game}.
  * </p>
- *
- *
  */
 public class DemoGame extends Game
 {
-    private GObject mPlayer;
-
-    private KeyEventHandler upAction = new KeyEventHandler()
+    private KeyEventHandler mCloseAction = new KeyEventHandler()
     {
         @Override
-        public void handle(KeyEvent keyEvent)
+        public void handle(KeyEvent event)
         {
-            mPlayer.moveTo(mPlayer.getX(), mPlayer.getY() + 10);
+            DemoGame.this.stop();
         }
     };
 
-    private KeyEventHandler rightAction = new KeyEventHandler()
+    private KeyEventHandler mUpAction = new KeyEventHandler()
     {
         @Override
         public void handle(KeyEvent keyEvent)
         {
-            mPlayer.moveTo(mPlayer.getX() + 10, mPlayer.getY());
+            final GObject obj = getSelected();
+            if (obj != null) {
+                obj.moveTo(obj.getX(), obj.getY() + 10);
+            }
         }
     };
 
-    private KeyEventHandler downAction = new KeyEventHandler()
+    private KeyEventHandler mRightAction = new KeyEventHandler()
     {
         @Override
         public void handle(KeyEvent keyEvent)
         {
-            mPlayer.moveTo(mPlayer.getX(), mPlayer.getY() - 10);
+            final GObject obj = getSelected();
+            if (obj != null) {
+                obj.moveTo(obj.getX() + 10, obj.getY());
+            }
         }
     };
 
-    private KeyEventHandler leftAction = new KeyEventHandler()
+    private KeyEventHandler mDownAction = new KeyEventHandler()
     {
         @Override
         public void handle(KeyEvent keyEvent)
         {
-            mPlayer.moveTo(mPlayer.getX() - 10, mPlayer.getY());
+            final GObject obj = getSelected();
+            if (obj != null) {
+                obj.moveTo(obj.getX(), obj.getY() - 10);
+            }
+        }
+    };
+
+    private KeyEventHandler mLeftAction = new KeyEventHandler()
+    {
+        @Override
+        public void handle(KeyEvent keyEvent)
+        {
+            final GObject obj = getSelected();
+            if (obj != null) {
+                obj.moveTo(obj.getX() - 10, obj.getY());
+            }
         }
     };
 
     /**
      * <p>Show selected {@link GObject}.</p>
      */
-    private MouseEventHandler showAction = new MouseEventHandler()
+    private MouseEventHandler mShowAction = new MouseEventHandler()
     {
         @Override
         public void handle(MouseEvent event)
@@ -79,7 +96,7 @@ public class DemoGame extends Game
     /**
      * <p>Hide selected {@link GObject}.</p>
      */
-    private MouseEventHandler hideAction = new MouseEventHandler()
+    private MouseEventHandler mHideAction = new MouseEventHandler()
     {
         @Override
         public void handle(MouseEvent event)
@@ -111,9 +128,10 @@ public class DemoGame extends Game
         this.setRoom(room);
 
         // Create player
-        mPlayer = goFactory.getGObject("char");
-        mPlayer.moveTo(300, 300);
-        mPlayer.getImageComponent().setTint(0.8f, 1f, 1f);
+        final GObject obj = goFactory.getGObject("char");
+        obj.moveTo(300, 300);
+        obj.getImageComponent().setTint(0.8f, 1f, 1f);
+        this.setSelected(obj);
 
         // Create untextured character
         final GObject character = goFactory.getGObject("char");
@@ -125,12 +143,17 @@ public class DemoGame extends Game
 
         // Hook View position into arrow keys
         final ControlMap input = getControlMap();
-        input.attach(KeyEvent.Key.KEY_UP, upAction);
-        input.attach(KeyEvent.Key.KEY_RIGHT, rightAction);
-        input.attach(KeyEvent.Key.KEY_DOWN, downAction);
-        input.attach(KeyEvent.Key.KEY_LEFT, leftAction);
-        input.attach(MouseEvent.Button.RIGHT, hideAction);
-        input.attach(MouseEvent.Button.MIDDLE, showAction);
+        input.attach(KeyEvent.Key.KEY_UP, mUpAction);
+        input.attach(KeyEvent.Key.KEY_RIGHT, mRightAction);
+        input.attach(KeyEvent.Key.KEY_DOWN, mDownAction);
+        input.attach(KeyEvent.Key.KEY_LEFT, mLeftAction);
+
+        // Allow game shutdown from ESC key
+        input.attach(KeyEvent.Key.KEY_ESCAPE, mCloseAction);
+
+        // Hide and show selected object
+        input.attach(MouseEvent.Button.RIGHT, mHideAction);
+        input.attach(MouseEvent.Button.MIDDLE, mShowAction);
 
         // Keep View from leaving the Room
         getView().setRoomConstrained(true);
@@ -139,12 +162,17 @@ public class DemoGame extends Game
     @Override
     protected void onUpdate()
     {
-        getView().moveToCenter(mPlayer);
+        final GObject obj = getSelected();
+        if (obj != null) {
+            getView().moveToCenter(obj);
+        }
     }
 
     @Override
     protected void onEnd()
     {
         getGObjectFactory().clear();
+        getBodyFactory().clear();
+        getImageFactory().clear();
     }
 }

--- a/com/cinnamon/demo/DemoVBOBuffer.java
+++ b/com/cinnamon/demo/DemoVBOBuffer.java
@@ -25,7 +25,7 @@ public final class DemoVBOBuffer extends GLBuffer
     private static final int SIZE_COLOR = 4;
     private static final int SIZE_MAT4 = 4 * 4;
 
-    private final float[] mProjection;
+    private float[] mProjection;
     private final int[] mConstantIndices;
 
     // Vertex array object
@@ -325,5 +325,11 @@ public final class DemoVBOBuffer extends GLBuffer
             mSelProjections = mProjections;
             mSelTranslations = mTranslations;
         }
+    }
+
+    @Override
+    public void setProjection(float[] matrix)
+    {
+        mProjection = matrix.clone();
     }
 }

--- a/com/cinnamon/gfx/GLBuffer.java
+++ b/com/cinnamon/gfx/GLBuffer.java
@@ -42,6 +42,13 @@ public abstract class GLBuffer
     public abstract void setInstancing(boolean enable);
 
     /**
+     * <p>Sets the projection matrix to use when drawing.</p>
+     *
+     * @param matrix projection matrix.
+     */
+    public abstract void setProjection(float[] matrix);
+
+    /**
      * <p>Enables a vertex attribute array at the specified location index
      * set up for a 4x4 matrix.</p>
      *

--- a/com/cinnamon/gfx/ShaderFactory.java
+++ b/com/cinnamon/gfx/ShaderFactory.java
@@ -271,7 +271,7 @@ public abstract class ShaderFactory
         {
             // Delete shader obj ids
             for (final ShaderObject shader : mNameMap.values()) {
-                mNameMap.get(shader.getName()).delete();
+                shader.delete();
             }
 
             // Clear lookup map

--- a/com/cinnamon/system/DebugCtrl.java
+++ b/com/cinnamon/system/DebugCtrl.java
@@ -575,7 +575,7 @@ public final class DebugCtrl
 
         // Intro text provides stop command and game shutdown reminder
         private static final String INTRO_MSG = "[Debug console enabled. To stop debug mode, enter \"" + STOP_CMD +
-                "\". To stop the game, enter \"" + SHUTDOWN + "\". For a list of supported commands, enter\"" + HELP +
+                "\". To stop the game, enter \"" + SHUTDOWN + "\". For a list of supported commands, enter \"" + HELP +
         "\"]";
 
         // Closing text to notify console will stop acting on input

--- a/com/cinnamon/system/DefaultInput.java
+++ b/com/cinnamon/system/DefaultInput.java
@@ -1,7 +1,10 @@
 package com.cinnamon.system;
 
 import com.cinnamon.utils.PooledQueue;
-import org.lwjgl.glfw.*;
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWKeyCallback;
+import org.lwjgl.glfw.GLFWMouseButtonCallback;
+import org.lwjgl.glfw.GLFWScrollCallback;
 
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -119,7 +122,7 @@ public final class DefaultInput extends Window.Input
     @Override
     void bind()
     {
-        final long windowId = this.getWindowId();
+        final long windowId = this.getId();
 
         // Attach input hooks to GLFW's window
         GLFW.glfwSetKeyCallback(windowId, new KeyboardHook());
@@ -130,7 +133,7 @@ public final class DefaultInput extends Window.Input
     @Override
     void unbind()
     {
-        final long windowId = this.getWindowId();
+        final long windowId = this.getId();
 
         // Detach input hooks
         GLFW.glfwSetKeyCallback(windowId, null);
@@ -186,7 +189,7 @@ public final class DefaultInput extends Window.Input
             }
 
             // Update mouse location
-            GLFW.glfwGetCursorPos(getWindowId(), mMouseX, mMouseY);
+            GLFW.glfwGetCursorPos(getId(), mMouseX, mMouseY);
             final float x = (float) mMouseX[0];
             final float y = (float) mMouseY[0];
 
@@ -214,7 +217,7 @@ public final class DefaultInput extends Window.Input
         @Override
         public void invoke(long window, double xoffset, double yoffset) {
             // Query mouse position on scroll
-            GLFW.glfwGetCursorPos(getWindowId(), mMouseX, mMouseY);
+            GLFW.glfwGetCursorPos(getId(), mMouseX, mMouseY);
             final float x = (float) mMouseX[0];
             final float y = (float) mMouseY[0];
 

--- a/com/cinnamon/system/KeyEvent.java
+++ b/com/cinnamon/system/KeyEvent.java
@@ -16,7 +16,7 @@ public final class KeyEvent extends InputEvent
     /**
      * <p>Number of supported keyboard keys.</p>
      */
-    public static final int SUPPORTED_KEYS = 75;
+    public static final int SUPPORTED_KEYS = 79;
 
     /**
      * <p>
@@ -50,7 +50,7 @@ public final class KeyEvent extends InputEvent
         KEY_PERIOD,
         KEY_FORWARD_SLASH,
 
-        // Auxiliary constants (16)
+        // Auxiliary constants (20)
         KEY_ESCAPE,
         KEY_ENTER,
         KEY_SPACE,
@@ -67,6 +67,10 @@ public final class KeyEvent extends InputEvent
         KEY_DOWN,
         KEY_LEFT,
         KEY_UP,
+        KEY_LEFT_SUPER,
+        KEY_RIGHT_SUPER,
+        KEY_PAGE_UP,
+        KEY_PAGE_DOWN,
 
         // Function constants (12)
         KEY_F1,
@@ -294,6 +298,15 @@ public final class KeyEvent extends InputEvent
                 return KEY_LEFT;
             case GLFW.GLFW_KEY_UP:
                 return KEY_UP;
+
+            case GLFW.GLFW_KEY_LEFT_SUPER:
+                return KEY_LEFT_SUPER;
+            case GLFW.GLFW_KEY_RIGHT_SUPER:
+                return KEY_RIGHT_SUPER;
+            case GLFW.GLFW_KEY_PAGE_UP:
+                return KEY_PAGE_UP;
+            case GLFW.GLFW_KEY_PAGE_DOWN:
+                return KEY_PAGE_DOWN;
             default: return null;
         }
     }
@@ -484,7 +497,7 @@ public final class KeyEvent extends InputEvent
     {
         switch (key) {
             case KEY_ESCAPE:
-                return "esc";
+                return "escape";
             case KEY_ENTER:
                 return "enter";
             case KEY_SPACE:
@@ -494,7 +507,7 @@ public final class KeyEvent extends InputEvent
             case KEY_TAB:
                 return "tab";
             case KEY_CAPS_LOCK:
-                return "capslock";
+                return "caps_lock";
             case KEY_LEFT_CTRL:
                 return "left_ctrl";
             case KEY_LEFT_SHIFT:
@@ -515,6 +528,14 @@ public final class KeyEvent extends InputEvent
                 return "left";
             case KEY_UP:
                 return "up";
+            case KEY_LEFT_SUPER:
+                return "left_super";
+            case KEY_RIGHT_SUPER:
+                return "right_super";
+            case KEY_PAGE_UP:
+                return "page up";
+            case KEY_PAGE_DOWN:
+                return "page down";
             default: return null;
         }
     }

--- a/com/cinnamon/system/OnResizeListener.java
+++ b/com/cinnamon/system/OnResizeListener.java
@@ -1,0 +1,22 @@
+package com.cinnamon.system;
+
+import com.cinnamon.gfx.Canvas;
+
+/**
+ * <p>
+ *     Listener to be used for changes in sizes such as with {@link Canvas#setOnResizeListener(OnResizeListener)}
+ *     when the {@link Window} is resized.
+ * .</p>
+ */
+public interface OnResizeListener
+{
+    /**
+     * <p>Called when there's a change in size..</p>
+     *
+     * @param oldWidth width before resize.
+     * @param oldHeight height before resize.
+     * @param width new width.
+     * @param height new height.
+     */
+    void onResize(float oldWidth, float oldHeight, float width, float height);
+}

--- a/com/cinnamon/system/View.java
+++ b/com/cinnamon/system/View.java
@@ -1,6 +1,5 @@
 package com.cinnamon.system;
 
-import com.cinnamon.gfx.Canvas;
 import com.cinnamon.gfx.ImageComponent;
 import com.cinnamon.object.BodyComponent;
 import com.cinnamon.object.GObject;
@@ -9,17 +8,21 @@ import com.cinnamon.utils.AxisAlignedRect;
 import com.cinnamon.utils.Rect2D;
 
 /**
- * <p>A View defines the visible area to be drawn on screen. While the View
- * itself moves in world coordinates, it can convert between screen and
- * world coordinates, as used in {@link #translateToWorld(MouseEvent)}.</p>
+ * <p>
+ *     A View defines the visible area to be drawn on screen. As such, the View's size cannot be larger than the
+ *     {@link Window} that hosts it.
+ * </p>
  *
- *
+ * <p>
+ *     While the View itself moves in world coordinates, it can convert between screen and world coordinates, as
+ *     shown through {@link #translateToWorld(MouseEvent)}.
+ * </p>
  */
-public class View
+public final class View
 {
-    // Minimum View dimensions
-    private static final int MIN_WIDTH = 1;
-    private static final int MIN_HEIGHT = 1;
+    // Minimum width and height allowed
+    private static final int MINIMUM_WIDTH = 1;
+    private static final int MINIMUM_HEIGHT = 1;
 
     // View's shape (and boundaries)
     private final Rect2D mBoundary;
@@ -31,52 +34,44 @@ public class View
     private boolean mConstrained = false;
 
     /**
-     * <p>Constructor for a rectangular View whose dimensions match that of
-     * the Canvas. That is, there will be no room for other Views.</p>
+     * <p>Constructor for a View whose dimensions fill the {@link Window}. The View's dimensions will match that of
+     * the Window.</p>
      *
-     * @param canvas Canvas to draw the View on.
+     * @param window Window to fill.
      */
-    View(Canvas canvas)
+    View(Window window)
     {
-        // Create View's shape based off of Canvas' dimensions
-        final int width = canvas.getWidth();
-        final int height = canvas.getHeight();
-        mBoundary = new AxisAlignedRect(width, height);
+        this(window, window.getWidth(), window.getHeight());
     }
 
     /**
-     * <p>Constructor for a rectangular View whose dimensions only show a
-     * part of the overall Canvas.</p>
+     * <p>Constructor for a View whose dimensions only show a part of the overall {@link Window}.</p>
      *
-     * @param canvas Canvas to draw the View on.
-     * @param width View width.
-     * @param height View height.
-     * @throws IllegalArgumentException if the width or height are < 1 and if
-     * they are greater than the width and height of the Canvas.
+     * @param window Window to represent a section of.
+     * @param width desired section width.
+     * @param height desired section height.
+     * @throws IllegalArgumentException if the width < {@link #MINIMUM_WIDTH}, height < {@link #MINIMUM_HEIGHT}, or
+     * if either is greater than the Window's current width and height.
      */
-    protected View(Canvas canvas, int width, int height)
+    public View(Window window, int width, int height)
     {
         // Check if width is valid
-        if (width < MIN_WIDTH) {
-            throw new IllegalArgumentException("Width must be at least " +
-                    MIN_WIDTH);
+        if (width < MINIMUM_WIDTH) {
+            throw new IllegalArgumentException("Width must be at least " + MINIMUM_WIDTH);
         }
-        if (width > canvas.getWidth()) {
-            throw new IllegalArgumentException("Width cannot be greater than " +
-                    "Canvas' width: " + canvas.getWidth());
+        if (width > window.getWidth()) {
+            throw new IllegalArgumentException("Width cannot be greater than Window's width: " + window.getWidth());
         }
 
         // Check if height is valid
-        if (height < MIN_HEIGHT) {
-            throw new IllegalArgumentException("Height must be at least " +
-                    MIN_HEIGHT);
+        if (height < MINIMUM_HEIGHT) {
+            throw new IllegalArgumentException("Height must be at least " + MINIMUM_HEIGHT);
         }
-        if (height > canvas.getHeight()) {
-            throw new IllegalArgumentException("Height cannot be greater than" +
-                    " Canvas' height: " + canvas.getHeight());
+        if (height > window.getHeight()) {
+            throw new IllegalArgumentException("Height cannot be greater than Window's height: " + window.getHeight());
         }
 
-        // Create View's shape
+        // Create View's bounding box
         mBoundary = new AxisAlignedRect(width, height);
     }
 
@@ -111,6 +106,18 @@ public class View
     }
 
     /**
+     * <p>Changes the View's size.</p>
+     *
+     * @param width width.
+     * @param height height.
+     */
+    public void setSize(float width, float height)
+    {
+        mBoundary.setWidth(width);
+        mBoundary.setHeight(height);
+    }
+
+    /**
      * <p>Gets the x position.</p>
      *
      * @return x.
@@ -131,9 +138,8 @@ public class View
     }
 
     /**
-     * <p>Attempts to move the View to a specific (x,y) point. If the View
-     * is room constrained, this method will position the View as close as
-     * it can to the target point.</p>
+     * <p>Attempts to move the View to a specific (x,y) point. If the View is room constrained, this method will
+     * position the View as close as it can to the target point.</p>
      *
      * @param x x.
      * @param y y.
@@ -150,8 +156,8 @@ public class View
     /**
      * <p>Moves the View to center on a {@link GObject}.</p>
      *
-     * <p>Centering will prioritize the position and dimensions of
-     * any {@link BodyComponent} over {@link ImageComponent}.</p>
+     * <p>Centering will prioritize the position and dimensions of any {@link BodyComponent} over
+     * {@link ImageComponent}.</p>
      *
      * @param object GObject.
      */
@@ -174,11 +180,9 @@ public class View
     }
 
     /**
-     * <p>Moves the View to a specific (x,y) point if doing so would not move
-     * the View's area beyond the set {@link Room}. If executing a move
-     * would move the View beyond the Room, this method will only partially
-     * apply the new position in that either of the offending x or y
-     * coordinates will be set to the Room's boundary.</p>
+     * <p>Moves the View to a specific (x,y) point if doing so would not move the View's area beyond the set
+     * {@link Room}. If executing a move would move the View beyond the Room, this method will only partially apply
+     * the new position in that either of the offending x or y coordinates will be set to the Room's boundary.</p>
      *
      * @param x x.
      * @param y y.
@@ -214,9 +218,8 @@ public class View
     }
 
     /**
-     * <p>Converts a given {@link MouseEvent} from the traditional top left
-     * origin coordinate system to game world coordinates (bottom left
-     * origin).</p>
+     * <p>Converts a given {@link MouseEvent} from the traditional top left origin coordinate system to game world
+     * coordinates (bottom left origin).</p>
      *
      * @param event MouseEvent.
      */
@@ -224,8 +227,7 @@ public class View
     {
         // Compute world-based coordinates
         final float worldX = event.getX() + mBoundary.getX();
-        float worldY = mBoundary.getHeight() - event.getY();
-        worldY += mBoundary.getY();
+        final float worldY = mBoundary.getHeight() - event.getY() + mBoundary.getY();
 
         // Update event with translated coords
         final MouseEvent.Button button = event.getButton();
@@ -234,9 +236,8 @@ public class View
     }
 
     /**
-     * <p>Checks whether or not an {@link ImageComponent} contains the
-     * View and is therefore visible, barring factors such as the component's
-     * set transparency.</p>
+     * <p>Checks whether or not an {@link ImageComponent} contains the View and is therefore visible, barring factors
+     * such as the component's set transparency.</p>
      *
      * @param component ImageComponent.
      * @return true if the ImageComponent contains the View's rectangle.
@@ -269,8 +270,7 @@ public class View
     }
 
     /**
-     * <p>Sets whether or not the View should be prevented from moving
-     * beyond the set {@link Room}.</p>
+     * <p>Sets whether or not the View should be prevented from moving beyond the set {@link Room}.</p>
      *
      * @param enable true to keep the View from leaving the Room.
      */


### PR DESCRIPTION
Added two command line argument formats for explicit resolution, debug mode, tickrate, and vsync for configurable running from bat files.

Window now makes a distinction between screen size and framebuffer size with new methods to query each as well as listeners when they change. Canvas and View have been updated to reflect Window's new size type with Canvas's getWidth() and getHeight() now refer to Window's framebuffer dimensions while View now uses Window instead of Canvas for working with screen coordinates.

Responsibility for instantiating a DefaultInput for Window is given to Game shortly before calling show() on the Window.

DemoGame has been given some usability treatment with escape key now quitting the game and selected game objects being controllable.

A handful of bug fixes.