### PR TITLE
Ease of use update 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,123 @@
+# Cinnamon
+Cinnamon is a Java framework for building 2D games intended as an educational hands-on exploration of engineering a large system.
+
+## Sounds like reinventing the wheel
+The purpose of this project is to gain exposure to and a better understanding of different algorithms, data structures, and problems that arise in their interaction through application. Plus, who doesn't want to know how video games work?
+
+## Can I use this for my own game?
+For now, it's not recommended. The Cinnamon engine is currently very much incomplete, buggy, and prone to frequent changes.
+
+## The Structure
+A game made with Cinnamon is drawn with OpenGL and centers around an instance of [Game](com/cinnamon/system/Game.java) and [Canvas2D](com/cinnamon/gfx/Canvas2D.java) working across two threads. In each game update (also known as a "tick"), a snapshot of the current visible scene is pushed to be drawn in the second thread. In turn, the snapshot is drawn as soon as possible, with the canvas redrawing the same scene if no new data is available.
+
+It should be noted that this project (and therefore the [demo](#demo)) has only been tested on Windows 10 64-bit, though more systems are planned to officially be supported.
+
+#### Game
+The main thread belongs to Game and performing game world related tasks such as processing input, collision detection, stepping objects through their physics, and the like.
+
+#### Canvas
+The second thread belongs to Canvas2D and the bulk of OpenGL calls. This helps ease the time it takes to process a game update since updating the game's state occurs in parallel to drawing (the previous state).
+
+## Demo
+A demo with a batch file for run configurations and a readme for controls is available in [artifacts](artifacts). The demo must be run through the batch file and not the jar. Currently, this demo is only available to be run on Windows.
+
+A console is provided to see exceptions as well as submit commands to examine the game world. These commands range from spawning a game object to reading an object's rotation; a full list is shown by typing "help". This demo consists of a simple room with simplistic physics displayed in fullscreen and using the ESC key to exit.
+
+Note that unlike the [Hello World](#hello-world) example, the initialization code for a Game instance is separated to the [DemoDriver](com/cinnamon/demo/DemoDriver.java) class in the demo.
+
+## Hello World
+In order to run, Cinnamon requires a subclass of each of the following (aside from [Game](com/cinnamon/system/Game.java)): [GObjectFactory](com/cinnamon/object/GObjectFactory.java), [BodyFactory](com/cinnamon/object/BodyFactory.java), [ImageFactory](com/cinnamon/gfx/ImageFactory.java), [ShaderFactory](com/cinnamon/gfx/ShaderFactory.java), and [Canvas2D](com/cinnamon/gfx/Canvas2D.java). Each of these factory classes provide game specific object configurations while the Canvas implementation facilitates drawing.
+
+In the example below, implementations prefixed with "Example" are assumed to exist. Required method overrides for subclasses of Game have been omitted for clarity.
+
+For an even more involved setup, see the [demo package](com/cinnamon/demo) where initialization is separated to a driver class.
+
+```java
+public class ExampleGame extends Game
+{
+    public static void main(String[] args)
+    {    
+        // Create game info: title, name, version
+        final Map<String, String> properties = createBasicProperties();
+
+        // Create directory of factories for assembling game objects
+        final Game.Resources res = new Resources();
+
+        // Instantiate a window and Canvas to draw on
+        final Window window = new Window(1920, 1080, properties.get(Game.TITLE), false);
+        final Canvas canvas = new ExampleCanvas(window, new ConcurrentSceneBuffer(), res.getShaderFactory());
+
+        // Begin the game
+        new ExampleGame(res, null, canvas, properties).start();
+    }
+
+    /**
+     *  <p>Creates a Map containing the game's title, author, and version.</p>
+     */
+    private static Map<String, String> createBasicProperties()
+    {
+        final Map<String, String> properties = new HashMap<String, String>();
+
+        // Fill with basic game info
+        properties.put(Game.TITLE, "Hello World");
+        properties.put(Game.DEVELOPER, "John Smith");
+        properties.put(Game.VERSION, "0.001a");
+
+        return properties;
+    }
+
+    /**
+     *  <p>
+     *      Directory responsible for providing factories that assemble game objects.
+     *  </p>
+     */
+    private static class Resources<ExampleGObject> extends Game.Resources
+    {
+        @Override
+        public GObjectFactory<ExampleGObject> getGObjectFactory()
+        {
+            return new ExampleGObjectFactory<ExampleGObject>();
+        }
+
+        @Override
+        public BodyFactory getBodyFactory()
+        {
+            return new ExampleBodyFactory();
+        }
+
+        @Override
+        public ImageFactory getImageFactory()
+        {
+            return new ExampleImageFactory();
+        }
+
+        @Override
+        public ShaderFactory getShaderFactory()
+        {
+            return new ExampleShaderFactory();
+        }
+    }
+}```
+
+## License
+MIT License
+
+Copyright (c) 2017 Christian Ramos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ public class ExampleGame extends Game
             return new ExampleShaderFactory();
         }
     }
-}```
+}
+```
 
 ## License
 MIT License

--- a/com/cinnamon/demo/DemoDriver.java
+++ b/com/cinnamon/demo/DemoDriver.java
@@ -5,9 +5,8 @@ import com.cinnamon.gfx.ConcurrentSceneBuffer;
 import com.cinnamon.gfx.ImageFactory;
 import com.cinnamon.gfx.ShaderFactory;
 import com.cinnamon.object.BodyFactory;
+import com.cinnamon.object.GObject;
 import com.cinnamon.object.GObjectFactory;
-import com.cinnamon.system.ControlMap;
-import com.cinnamon.system.EventHub;
 import com.cinnamon.system.Game;
 import com.cinnamon.system.Window;
 
@@ -112,14 +111,14 @@ public class DemoDriver
         final Window window = new Window(resolution[0], resolution[1], props.get(Game.TITLE), debugEnabled);
 
         // Prepare game resource such as factories
-        final Game.Resources res = new CustomResources();
+        final Game.Resources<GObject> res = new CustomResources();
 
         // Prepare Canvas for drawing
         final ConcurrentSceneBuffer sceneBuffer = new ConcurrentSceneBuffer();
         final Canvas canvas = new DemoCanvas(window, sceneBuffer, res.getShaderFactory());
 
         // Begin game
-        new DemoGame(res, new CustomServices(), canvas, props).start();
+        new DemoGame(res, null, canvas, props).start();
     }
 
     /**
@@ -249,11 +248,11 @@ public class DemoDriver
      *     Provides the {@link Game} with a directory of customized resources for constructing game objects.
      * </p>
      */
-    private static class CustomResources extends Game.Resources
+    private static class CustomResources extends Game.Resources<GObject>
     {
         private ShaderFactory mShaderFactory = new DemoShaderFactory();
         private ImageFactory mImgFactory = new DemoImageFactory(mShaderFactory);
-        private GObjectFactory mGObjectFactory = new DemoGObjectFactory(this);
+        private GObjectFactory<GObject> mGObjectFactory = new DemoGObjectFactory(this);
         private BodyFactory mBodyFactory = new DemoBodyFactory();
 
         @Override
@@ -269,7 +268,7 @@ public class DemoDriver
         }
 
         @Override
-        public GObjectFactory getGObjectFactory()
+        public GObjectFactory<GObject> getGObjectFactory()
         {
             return mGObjectFactory;
         }
@@ -278,27 +277,6 @@ public class DemoDriver
         public BodyFactory getBodyFactory()
         {
             return mBodyFactory;
-        }
-    }
-
-    /**
-     * <p>
-     *     Returns null for each method returning a service. This tells {@link Game} to provide its own
-     *     implementations.
-     * </p>
-     */
-    private static class CustomServices extends Game.Services
-    {
-        @Override
-        public EventHub getEventHub()
-        {
-            return null;
-        }
-
-        @Override
-        public ControlMap getControlMap()
-        {
-            return null;
         }
     }
 }

--- a/com/cinnamon/system/Game.java
+++ b/com/cinnamon/system/Game.java
@@ -183,11 +183,12 @@ public abstract class Game<E extends GObject>
         mSolver = new Solver(getBodyFactory(), mTickRate);
 
         // Use given EventHub or use default if none provided
-        final EventHub eventHub = services.getEventHub();
+        final boolean noService = services == null;
+        final EventHub eventHub = (noService) ? null : services.getEventHub();
         mEventHub = (eventHub == null) ? new DefaultEventHub() : eventHub;
 
         // Use given ControlMap or use default if none provided
-        final ControlMap ctrl = services.getControlMap();
+        final ControlMap ctrl = (noService) ? null : services.getControlMap();
         mControlMap = (ctrl == null) ? new DefaultControlMap() : ctrl;
 
         // Create default Window.Input if none was set


### PR DESCRIPTION
## Readme
Added a readme for the front page explaining what Cinnamon is, the two-thread model, and showing a bit of initialization code.

## Demo
Added a zip to the new artifacts folder containing the setup to run the example in the demo subpackage. The example can be run through the included batch file - directly running the jar won't work since the example requires explicit arguments like resolution and the game's tickrate.

### Minor update to Game and DemoDriver
I've changed Game's constructor to instantiate default services even if no actual Services object was passed in. Forcing a Services implementation when no customized Services were to be provided felt unnecessary.
